### PR TITLE
Use JSON encoding for cached data

### DIFF
--- a/lib/kv-extreme-scale.js
+++ b/lib/kv-extreme-scale.js
@@ -12,8 +12,10 @@ const extend = require('util')._extend;
 const request = require('request');
 const util = require('util');
 
+const AssertionError = assert.AssertionError;
 const Connector = connectorCore.Connector;
 const BinaryPacker = connectorCore.BinaryPacker;
+const JsonStringPacker = connectorCore.JSONStringPacker;
 const ModelKeyComposer = connectorCore.ModelKeyComposer;
 
 exports.initialize = function initializeDataSource(dataSource, callback) {
@@ -54,7 +56,22 @@ function ExtremeScaleKVConnector(settings, dataSource) {
 
   this._strictSSL = settings.strictSSL;
   this._cookieJar = request.jar();
-  this._packer = new BinaryPacker();
+
+  switch (settings.packer) {
+    case 'binary':
+      this._packer = new BinaryPacker();
+      this._contentType = 'application/octet-stream';
+      break;
+    case 'json':
+    case undefined:
+      this._packer = new JsonStringPacker();
+      this._contentType = 'application/json';
+      break;
+    default:
+      throw new AssertionError(
+        'Unknown packer ' + JSON.stringify(settings.packer));
+  }
+
   this.DataAccessObject = dataSource.juggler.KeyValueAccessObject;
 };
 
@@ -109,7 +126,7 @@ function(composedKey, body, ttl, callback) {
     qs: {ttl: ttl ? +ttl / 1000 : undefined},
     body: body,
     headers: {
-      'content-type': 'application/octet-stream',
+      'content-type': this._contentType,
     },
   };
 
@@ -173,7 +190,7 @@ ExtremeScaleKVConnector.prototype._get = function(composedKey, callback) {
       body = null;
     }
 
-    return callback(err, body);
+    return callback(err, body, res && res.headers);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
   "homepage": "https://github.com/strongloop/loopback-connector-kv-extreme-scale#readme",
   "devDependencies": {
     "async-iterators": "^0.2.2",
+    "chai": "^3.5.0",
+    "dirty-chai": "^1.2.2",
     "eslint": "^3.10.2",
     "eslint-config-loopback": "^4.0.0",
     "loopback-datasource-juggler": "^3.0.0",
@@ -38,7 +40,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "loopback-connector": "^2.6.0",
+    "loopback-connector": "^2.7.0",
     "request": "^2.75.0"
   }
 }

--- a/test/helpers/data-source-factory.js
+++ b/test/helpers/data-source-factory.js
@@ -38,6 +38,14 @@ createDataSource.failing = function(options) {
   return createDataSource(settings);
 };
 
+createDataSource.binary = function(options) {
+  const settings = extend({
+    packer: 'binary',
+  }, options);
+
+  return createDataSource(settings);
+};
+
 beforeEach(function clearDatabase(done) {
   this.timeout(10000);
   const ds = createDataSource();

--- a/test/helpers/describe.js
+++ b/test/helpers/describe.js
@@ -1,0 +1,13 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: loopback-connector-kv-extreme-scale
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+module.exports = (desc, fn) => {
+  if (process.env.CI)
+    describe.skip(desc, fn);
+  else
+    describe(desc, fn);
+};

--- a/test/helpers/expect.js
+++ b/test/helpers/expect.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const chai = require('chai');
+chai.use(require('dirty-chai'));
+
+module.exports = chai.expect;

--- a/test/integration/juggler-api.integration.js
+++ b/test/integration/juggler-api.integration.js
@@ -6,20 +6,24 @@
 'use strict';
 
 const createDataSource = require('../helpers/data-source-factory');
+const describe = require('../helpers/describe');
+const kvaoTestSuite = require('loopback-datasource-juggler/test/kvao.suite.js');
 
-describeIf(!process.env.CI, 'Juggler API', function() {
+const connectorCapabilities = {
+  canExpire: false,
+  canQueryTtl: false,
+  ttlPrecision: 1000,
+  canIterateLargeKeySets: false,
+};
+
+describe('Juggler API', function() {
   this.timeout(20000);
-  require('loopback-datasource-juggler/test/kvao.suite.js')(createDataSource, {
-    canExpire: false,
-    canQueryTtl: false,
-    ttlPrecision: 1000,
-    canIterateLargeKeySets: false,
+
+  context('using default json-string packer', function() {
+    kvaoTestSuite(createDataSource, connectorCapabilities);
+  });
+
+  context('using binary packer', function() {
+    kvaoTestSuite(createDataSource.binary, connectorCapabilities);
   });
 });
-
-function describeIf(cond, desc, fn) {
-  if (cond)
-    describe(desc, fn);
-  else
-    describe.skip(desc, fn);
-}

--- a/test/integration/packer.integration.js
+++ b/test/integration/packer.integration.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const createDataSource = require('../helpers/data-source-factory');
+const describe = require('../helpers/describe');
+const expect = require('../helpers/expect');
+const extend = require('util')._extend;
+
+const aValue = {foo: 'bar'};
+
+describe('packer option', () => {
+  describe('json', () => {
+    let ds;
+    beforeEach('create json datasource', () => {
+      ds = createDataSource();
+    });
+
+    it('is used as the default storage format', (done) => {
+      const complexObjectValue = {
+        name: 'a-string',
+        age: 42,
+        flag: true,
+        date: new Date(),
+      };
+
+      ds.connector.set('TestModel', 'a-key', complexObjectValue, {}, (err) => {
+        if (err) return done(err);
+        ds.connector._get('TestModel:a-key', (err, result) => {
+          if (err) return done(err);
+          const stored = JSON.parse(result.toString());
+          const expected = JSON.parse(JSON.stringify(complexObjectValue));
+          expect(stored).to.eql(expected);
+          done();
+        });
+      });
+    });
+
+    it('sets correct Content-Type header', (done) => {
+      ds.connector.set('TestModel', 'another-key', aValue, {}, (err) => {
+        if (err) return done(err);
+        ds.connector._get('TestModel:another-key', (err, body, headers) => {
+          if (err) return done(err);
+          // allow additional parameters like "appliction/json; charset=UTF-8"
+          expect(headers['content-type']).to.match(/^application\/json\b/);
+          done();
+        });
+      });
+    });
+  });
+
+  describe('binary', () => {
+    let ds;
+    beforeEach('create binary datasource', () => {
+      ds = createDataSource.binary();
+    });
+
+    it('uses selected packer', (done) => {
+      ds.connector.set('TestModel', 'a-key', aValue, {}, (err) => {
+        if (err) return done(err);
+        ds.connector._get('TestModel:a-key', (err, result) => {
+          if (err) return done(err);
+          expect(result.toString('hex'))
+            .to.equal('81a3666f6fa3626172');
+          done();
+        });
+      });
+    });
+
+    it('sets correct Content-Type header', () => {
+      ds.connector.set('TestModel', 'another-key', aValue, {}, (err) => {
+        if (err) return done(err);
+        ds.connector._get('TestModel:another-key', (err, body, headers) => {
+          if (err) return done(err);
+          expect(headers['content-type']).to.equal('application/octet-stream');
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add a new option "packer" that allows users to select what encoding they prefer:
 - "json"
 - "binary" (using msgpack5)

Change the default packer to "json", since JSON data is easier to share between Node.js and Java applications.

See also https://github.com/strongloop/loopback-connector-kv-redis/pull/16 which introduced similar change in the KV-Redis connector.

Connect to strongloop-internal/scrum-loopback#1172

@superkhau please review
@ritch FYI

(Note that the pull request is based on top of #7 and the first two commits will be rebased out after #7 is landed. It's enough to review the last commit.)